### PR TITLE
chore : fix not null violation issue when creating fake chats for showing it on chat's index page

### DIFF
--- a/app/Livewire/Chats/Index.php
+++ b/app/Livewire/Chats/Index.php
@@ -28,8 +28,10 @@ class Index extends Component
     public function render(): View
     {
         // add 10 chats to the database with the factory
-        // Chat::factory()->count(10)->create(['room_id' => $this->roomId]); // only uncomment once
-        // $this->roomId = 1;
+
+        // Chat::factory()->count(10)->create(['room_id' => Room::factory()->create()->id]); // only uncomment once
+        $this->roomId = 1;
+
         return view('livewire.chats.index', [
             'room' => $this->room,
             'chats' => $this->room !== null ? Chat::query()->where('room_id', $this->roomId)->get() : [],

--- a/app/Livewire/Chats/Index.php
+++ b/app/Livewire/Chats/Index.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Chats;
 
 use App\Models\Chat;
 use App\Models\Room;
+use App\Models\User;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
@@ -27,10 +28,17 @@ class Index extends Component
 
     public function render(): View
     {
+        // get the current auth user
+        $user = auth()->user(); 
+
+        // stop phpstan related errors by assert $user as instance of User model 
+        assert($user instanceof User);
+
         // add 10 chats to the database with the factory
 
-        // Chat::factory()->count(10)->create(['room_id' => Room::factory()->create()->id]); // only uncomment once
-        $this->roomId = 1;
+        // Chat::factory()->count(10)->create(['room_id' =>  $user->rooms()->create(['name' => 'example room'])->id]); // only uncomment once
+
+        $this->roomId = $user->rooms()->latest()->first()?->id;
 
         return view('livewire.chats.index', [
             'room' => $this->room,

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -29,6 +29,16 @@ class Room extends Model
     use HasFactory;
 
     /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'user_id',
+    ];
+
+    /**
      * Get the user that owns the room.
      *
      * @return BelongsTo<User, Room>


### PR DESCRIPTION
This PR fixes , integrity constraint violation: 19 NOT NULL chats.room_id issue.
actually when uncommenting chat factory line, creates this issue as it's not creating room record and try to insert hardcode id which doesn't exists. 

merging this PR will provide quicker development on chat module

![image](https://github.com/user-attachments/assets/77ba26e2-549c-4086-b781-eff7582f93a2)
