### PR TITLE
Feat: edit chat

### DIFF
--- a/app/Events/ChatUpdated.php
+++ b/app/Events/ChatUpdated.php
@@ -11,7 +11,7 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
-class ChatCreated implements ShouldBroadcast
+class ChatUpdated implements ShouldBroadcast
 {
     use Dispatchable;
     use InteractsWithSockets;
@@ -39,6 +39,6 @@ class ChatCreated implements ShouldBroadcast
 
     public function broadcastAs(): string
     {
-        return 'chat-created';
+        return 'chat-updated';
     }
 }

--- a/app/Livewire/Chats/Create.php
+++ b/app/Livewire/Chats/Create.php
@@ -59,7 +59,7 @@ class Create extends Component
                 roomId: $this->roomId,
             ))->toOthers();
 
-            $this->dispatch('chat:updated.'.$this->chatId);
+            $this->dispatch('chat:updated.'.$this->pull('chatId'));
 
             return;
         }

--- a/app/Livewire/Chats/Create.php
+++ b/app/Livewire/Chats/Create.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Chats;
 
 use App\Events\ChatCreated;
+use App\Events\ChatUpdated;
 use App\Models\Room;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
@@ -23,7 +24,17 @@ class Create extends Component
     #[Validate('required|string')]
     public string $message;
 
-    public function store(): void
+    #[Locked]
+    public ?int $chatId = null;
+
+    #[On('chat-editing')]
+    public function startEditing(int $chatId, string $message): void
+    {
+        $this->chatId = $chatId;
+        $this->message = $message;
+    }
+
+    public function save(): void
     {
         $this->validate();
 
@@ -34,6 +45,24 @@ class Create extends Component
             ->exists();
 
         Gate::denyIf(! $memberExists, 'You are not a member of this room.');
+
+        if ($this->chatId !== null && $this->chatId !== 0) {
+            $chat = $room->chats()->findOrFail($this->chatId);
+            Gate::denyIf($chat->user_id !== auth()->id(), 'You are not the owner of this chat.');
+
+            $chat->update([
+                'message' => $this->pull('message'),
+            ]);
+
+            broadcast(new ChatUpdated(
+                chatId: $chat->id,
+                roomId: $this->roomId,
+            ))->toOthers();
+
+            $this->dispatch('chat:updated.'.$this->chatId);
+
+            return;
+        }
 
         $chat = $room->chats()->create([
             'user_id' => auth()->id(),
@@ -48,9 +77,28 @@ class Create extends Component
         $this->dispatch('chat:created');
     }
 
+    /**
+     * @param  array{roomId: int, chatId: int}  $event
+     */
     #[On('echo-private:chats.{roomId},.chat-created')]
-    public function chatCreated($event): void {
+    public function chatCreated(array $event): void
+    {
         $this->dispatch('chat:created');
+    }
+
+    /**
+     * @param  array{roomId: int, chatId: int}  $event
+     */
+    #[On('echo-private:chats.{roomId},.chat-updated')]
+    public function chatUpdated(array $event): void
+    {
+        $this->dispatch('chat:updated.'.$event['chatId']);
+    }
+
+    public function cancel(): void
+    {
+        $this->message = '';
+        $this->chatId = null;
     }
 
     public function render(): View

--- a/app/Livewire/Chats/Show.php
+++ b/app/Livewire/Chats/Show.php
@@ -6,11 +6,18 @@ namespace App\Livewire\Chats;
 
 use App\Models\Chat;
 use Illuminate\View\View;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('chat:updated.{chat.id}')]
 class Show extends Component
 {
     public Chat $chat;
+
+    public function edit(): void
+    {
+        $this->dispatch('chat-editing', chatId: $this->chat->id, message: $this->chat->message);
+    }
 
     public function render(): View
     {

--- a/app/Livewire/Rooms/Create.php
+++ b/app/Livewire/Rooms/Create.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Rooms;
 
+use App\Models\Room;
 use App\Models\User;
 use Illuminate\View\View;
 use Livewire\Attributes\Validate;
@@ -39,8 +40,9 @@ class Create extends Component
         /** @var array{members: array<int>, name: string} $validated */
         $validated = $this->validate();
 
-        $room = auth()->user()->rooms()->create([
-            'name' => $validated['name'],
+        $room = Room::create([
+            'name' => $this->pull('name'),
+            'user_id' => auth()->id(),
         ]);
 
         $validated['members'][] = auth()->id();

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -46,6 +46,7 @@ class Room extends Model
      */
     public function users(): BelongsToMany
     {
+        // @phpstan-ignore-next-line
         return $this->belongsToMany(User::class, 'members');
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -6,7 +6,7 @@ namespace App\Models;
 
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -54,11 +54,13 @@ class User extends Authenticatable
     /**
      * Get the rooms for the user.
      *
-     * @return HasMany<Room ,$this>
+     * @return BelongsToMany<Room, $this>
      */
-    public function rooms(): HasMany
+    public function rooms(): BelongsToMany
     {
-        return $this->hasMany(Room::class);
+        // @phpstan-ignore-next-line
+        return $this->belongsToMany(Room::class, 'members')
+            ->withTimestamps();
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\ValueObject\PhpVersion;
+use RectorLaravel\Rector\StaticCall\EloquentMagicMethodToQueryBuilderRector;
 use RectorLaravel\Set\LaravelSetList;
 
 return RectorConfig::configure()
@@ -35,4 +36,8 @@ return RectorConfig::configure()
         LaravelSetList::LARAVEL_ELOQUENT_MAGIC_METHOD_TO_QUERY_BUILDER,
         LaravelSetList::LARAVEL_CONTAINER_STRING_TO_FULLY_QUALIFIED_NAME,
         LaravelSetList::LARAVEL_ARRAYACCESS_TO_METHOD_CALL,
+    ])->withConfiguredRule(EloquentMagicMethodToQueryBuilderRector::class, [
+        'exclude_methods' => [
+            'create',
+        ],
     ])->withImportNames();

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,11 +1,11 @@
 import './bootstrap';
 import { Livewire, Alpine } from '../../vendor/livewire/livewire/dist/livewire.esm'
-import { storeChat } from './store-chat.js'
+import { saveChat } from './save-chat.js'
 import { notifications, notify } from './notification.js'
 
 window.Alpine = Alpine
 
-Alpine.data('storeChat', storeChat)
+Alpine.data('saveChat', saveChat)
 Alpine.data('notifications', notifications)
 
 window.Alpine.plugin(notify)

--- a/resources/js/save-chat.js
+++ b/resources/js/save-chat.js
@@ -1,7 +1,7 @@
-export const storeChat = () => ({
-    async store() {
+export const saveChat = () => ({
+    async save() {
         if (this.$wire.message === '') return;
-        await this.$wire.store();
+        await this.$wire.save();
         this.$wire.message = '';
     }
 })

--- a/resources/views/livewire/chats/create.blade.php
+++ b/resources/views/livewire/chats/create.blade.php
@@ -1,5 +1,5 @@
 <div class="mt-4">
-    <div x-data="storeChat">
+    <div x-data="saveChat">
         <div class="flex items-center gap-3">
             <x-text-input
                 wire:model="message"
@@ -11,13 +11,31 @@
                 placeholder="Type your message here..."
             />
 
-            <button
-                type="button"
-                x-on:click="store"
-                class="text-white font-bold bg-blue-500 py-2 px-4 rounded-sm disabled:cursor-not-allowed cursor-pointer"
-            >
-                Send
-            </button>
+            @if($chatId === null)
+                <button
+                    type="button"
+                    x-on:click="save"
+                    class="text-white font-bold bg-blue-500 py-2 px-4 rounded-sm disabled:cursor-not-allowed cursor-pointer"
+                >
+                    Send
+                </button>
+            @else
+                <button
+                    type="button"
+                    x-on:click="save"
+                    class="text-white font-bold bg-blue-500 py-2 px-4 rounded-sm disabled:cursor-not-allowed cursor-pointer"
+                >
+                    Update
+                </button>
+
+                <button
+                    type="button"
+                    wire:click="cancel"
+                    class="text-white font-bold bg-red-500 py-2 px-4 rounded-sm disabled:cursor-not-allowed cursor-pointer"
+                >
+                    Cancel
+                </button>
+            @endif
         </div>
     </div>
 </div>

--- a/resources/views/livewire/chats/show.blade.php
+++ b/resources/views/livewire/chats/show.blade.php
@@ -1,40 +1,64 @@
 <div @class([
-'flex items-center space-x-2',
-'justify-end' => $isCurrentUser,
+    'flex items-center space-x-2',
+    'justify-end' => $isCurrentUser,
 ])>
-    @if (! $isCurrentUser)
+    @if (!$isCurrentUser)
         <figure class="flex shrink-0 self-start">
-            <img src="{{ $chat->user->profile }}" alt="{{ $chat->user->name }}"
-                class="h-8 w-8 object-cover rounded-full">
+            <img
+                src="{{ $chat->user->profile }}"
+                alt="{{ $chat->user->name }}"
+                class="h-8 w-8 object-cover rounded-full"
+            >
         </figure>
     @endif
-    <div class="flex items-center justify-center space-x-2">
-        <div class="block">
-            <div class="w-auto rounded-xl px-2 pb-2">
-                <div @class([
-                    'font-medium text-gray-800 dark:text-gray-100',
-                    'text-right' => $isCurrentUser,
-                ])>
-                    <small class="text-sm sm:text-md">
-                        {{ $chat->user->name }}
-                    </small>
-                </div>
-                <div @class([
-                    'text-xs sm:text-sm bg-slate-100 dark:bg-gray-700 dark:text-gray-400 p-2',
-                    'rounded-tl-3xl rounded-bl-3xl rounded-br-xl' => $isCurrentUser,
-                    'rounded-tr-3xl rounded-br-3xl rounded-bl-xl' => !$isCurrentUser,
-                ])>
-                    <p>
-                        {{ $chat->message }}
-                    </p>
-                </div>
+    <div class="flex flex-col max-w-md">
+        <div @class([
+            'flex items-center mb-1',
+            'justify-end' => $isCurrentUser,
+        ])>
+            <small class="text-xs text-gray-500 dark:text-gray-400">
+                {{ $chat->user->name }}
+            </small>
+            @if ($chat->updated_at > $chat->created_at)
+                <span class="text-xs text-gray-400 dark:text-gray-500 mx-1">(edited)</span>
+            @endif
+        </div>
+
+        <div @class([
+            'relative group ps-6 rounded-lg',
+            'text-right' => $isCurrentUser,
+        ])>
+            <div @class([
+                'inline-block p-3 rounded-lg shadow-sm',
+                'bg-blue-500 text-white rounded-tr-none' => $isCurrentUser,
+                'bg-gray-100 dark:bg-gray-700 dark:text-gray-200 rounded-tl-none' => !$isCurrentUser,
+            ])>
+                <p class="text-sm">
+                    {{ $chat->message }}
+                </p>
             </div>
+
+            <button wire:click="edit" class="opacity-0 group-hover:opacity-100 transition-opacity absolute -top-1 left-0 p-1 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                    <path d="M17.414 2.586a2 2 0 00-2.828 0L3.586 12.586a1 1 0 00-.293.707V16a2 2 0 002 2h2.707a1 1 0 00.707-.293l11-11a2 2 0 000-2.828zM5.414 15H4v-1.414l10-10L15.414 4l-10 10z" />
+                </svg>
+            </button>
+        </div>
+
+        <div @class([
+            'text-xs text-gray-400 mt-1',
+            'text-right' => $isCurrentUser,
+        ])>
+            {{ $chat->updated_at->diffForHumans() }}
         </div>
     </div>
     @if ($isCurrentUser)
         <figure class="flex shrink-0 self-start">
-            <img src="{{ $chat->user->profile }}" alt="{{ $chat->user->name }}"
-                class="h-8 w-8 object-cover rounded-full">
+            <img
+                src="{{ $chat->user->profile }}"
+                alt="{{ $chat->user->name }}"
+                class="h-8 w-8 object-cover rounded-full"
+            >
         </figure>
     @endif
 </div>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -2,12 +2,15 @@
 
 declare(strict_types=1);
 
+use App\Models\User;
 use Illuminate\Support\Facades\Broadcast;
 
 Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
     return (int) $user->id === (int) $id;
 });
 
-Broadcast::channel('chats.{roomId}', function ($user, $roomId) {
-    return $user->rooms()->where('room_id', $roomId)->exists();
+Broadcast::channel('chats.{roomId}', function (User $user, int $roomId) {
+    return $user->rooms()
+        ->where('rooms.id', $roomId)
+        ->exists();
 });

--- a/tests/Feature/ChatsTest.php
+++ b/tests/Feature/ChatsTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Chats\Index as ChatsIndex;
 use App\Livewire\Chats\Create as CreateChat;
+use App\Livewire\Chats\Index as ChatsIndex;
 use App\Livewire\Pages\Chats;
 use App\Livewire\Rooms\Create as CreateRoom;
 use App\Livewire\Rooms\Index as RoomsIndex;
@@ -23,14 +23,14 @@ test('chats page is displayed', function () {
         ->assertOk();
 });
 
-test('create chat component should be there if room is selected', function () : void {
+test('create chat component should be there if room is selected', function (): void {
     $user = User::factory()->create();
     $room = Room::factory()
         ->hasAttached($user, relationship: 'users')
         ->create();
 
     $this->actingAs($user)
-        ->get('/chats?roomId=' . $room->id)
+        ->get('/chats?roomId='.$room->id)
         ->assertSeeLivewire(Chats::class)
         ->assertSeeLivewire(ChatsIndex::class)
         ->assertSeeLivewire(RoomsIndex::class)

--- a/tests/Unit/Livewire/Chats/ShowTest.php
+++ b/tests/Unit/Livewire/Chats/ShowTest.php
@@ -13,3 +13,15 @@ it('can render', function (): void {
         ->assertSee($chat->message)
         ->assertSee($chat->user->name);
 });
+
+it('can edit', function (): void {
+    $chat = Chat::factory()->create();
+
+    Livewire::actingAs($chat->user)
+        ->test(Show::class, ['chat' => $chat])
+        ->call('edit')
+        ->assertDispatched('chat-editing',
+            chatId: $chat->id,
+            message: $chat->message,
+        );
+});


### PR DESCRIPTION
This pull request includes several changes to improve the chat functionality, refactor code, and update tests in the application. The most important changes include the addition of a new `ChatUpdated` event, modifications to the `Create` and `Show` Livewire components, and updates to the JavaScript code and Blade templates to support chat editing. Additionally, there are various refactorings and test updates.

### Chat Functionality Enhancements:
* Added a new `ChatUpdated` event to handle chat updates, including broadcasting and handling the event in the `Create` and `Show` Livewire components (`app/Events/ChatUpdated.php`, `app/Livewire/Chats/Create.php`, `app/Livewire/Chats/Show.php`). [[1]](diffhunk://#diff-056eecf96c27396e9fec234cd8e52878535a29e56de35079a2e00406f4455a1aR1-R44) [[2]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdR8) [[3]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdL26-R37) [[4]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdR49-R66) [[5]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdR80-R103) [[6]](diffhunk://#diff-c3acd6ad1e7797c5250ee85b05815d850557a53dd2e8ea30f139cc5bcbdc3529R9-R21)

### Code Refactoring:
* Refactored the `ChatCreated` event to use individual traits for better readability (`app/Events/ChatCreated.php`).
* Updated the `rooms` relationship in the `User` model to use `BelongsToMany` instead of `HasMany` (`app/Models/User.php`).
* Modified the `store` method in the `Create` Livewire component to handle chat updates and renamed it to `save` (`app/Livewire/Chats/Create.php`). [[1]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdR49-R66) [[2]](diffhunk://#diff-1f33a345c90f69a446c49a84276a3a3ab2610e8e5adc26afa6bf2db4530ed1fdR80-R103)

### JavaScript and Blade Template Updates:
* Renamed `storeChat` to `saveChat` in the JavaScript code and updated the related Blade templates to support chat editing and saving (`resources/js/app.js`, `resources/js/save-chat.js`, `resources/views/livewire/chats/create.blade.php`). [[1]](diffhunk://#diff-583a1f586bc298813341bce6fec77a1f6338f2559471fe600f15a18316fe82bdL3-R8) [[2]](diffhunk://#diff-84b032944be30d8d917f7370424ab79851929c71ffe817b5670e8a2794496ca6L1-R4) [[3]](diffhunk://#diff-c1789a26ab8374143374f2ab973848b90f067f5a00cbfad8057004f4039dd9bcL2-R2) [[4]](diffhunk://#diff-c1789a26ab8374143374f2ab973848b90f067f5a00cbfad8057004f4039dd9bcR14-R38)

### Test Updates:
* Updated tests to reflect the changes in the `Create` Livewire component, including the renaming of the `store` method to `save` and handling chat updates (`tests/Unit/Livewire/Chats/CreateTest.php`). [[1]](diffhunk://#diff-c1e3896834a3ee83ee9a6cd23065791d454a272988777be11574f7258f4599d1L12-L36) [[2]](diffhunk://#diff-c1e3896834a3ee83ee9a6cd23065791d454a272988777be11574f7258f4599d1L46-R32) [[3]](diffhunk://#diff-c1e3896834a3ee83ee9a6cd23065791d454a272988777be11574f7258f4599d1L65-R51)

### Miscellaneous:
* Added the `EloquentMagicMethodToQueryBuilderRector` rule to the Rector configuration (`rector.php`). [[1]](diffhunk://#diff-d933a2ad57daa43419b483d3f1ddedaec7aa44933007fead9f9437390f596f4aR7) [[2]](diffhunk://#diff-d933a2ad57daa43419b483d3f1ddedaec7aa44933007fead9f9437390f596f4aR39-R42)
* Improved the `Show` Blade template to display edit buttons and updated timestamps for edited chats (`resources/views/livewire/chats/show.blade.php`).