### PR TITLE
feat: show currently active room in sidebar component.

### DIFF
--- a/app/Livewire/Rooms/Index.php
+++ b/app/Livewire/Rooms/Index.php
@@ -12,6 +12,14 @@ use Livewire\Component;
 #[On('room-created')]
 class Index extends Component
 {
+    public ?int $activeRoomId = null;
+
+    #[On('room-selected')]
+    public function getActiveRoomId(int $id): void
+    {
+        $this->activeRoomId = $id;
+    }
+
     public function render(): View
     {
         return view('livewire.rooms.index', [

--- a/resources/views/livewire/rooms/index.blade.php
+++ b/resources/views/livewire/rooms/index.blade.php
@@ -29,7 +29,12 @@
             class="mt-4 h-[calc(100vh-155px)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100">
             <div class="flex flex-col gap-4">
                 @forelse ($rooms as $room)
-                    <div class="bg-white dark:bg-gray-700 shadow-md rounded-lg py-4 cursor-pointer"
+                    <div
+                        @class([
+                            'shadow-md rounded-lg py-4 cursor-pointer',
+                            'bg-gray-50 dark:bg-gray-600 border border-1 dark:border-blue-300' => $room->id == $activeRoomId,
+                            'bg-white dark:bg-gray-700' => $room->id != $activeRoomId,
+                        ]) 
                         x-on:click="$dispatch('room-selected', { id: {{ $room->id }} })">
                         <div class="group flex items-center gap-3 px-4">
                             <figure

--- a/tests/Unit/Livewire/Rooms/IndexTest.php
+++ b/tests/Unit/Livewire/Rooms/IndexTest.php
@@ -31,3 +31,13 @@ test('sidebar component without rooms', function () {
         ->test(Index::class)
         ->assertSee('No rooms found');
 });
+
+test('sidebar component can show active room', function () {
+    $user = User::factory()->create();
+    $room = Room::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->dispatch('room-selected', id: $room->id)
+        ->assertSet('activeRoomId', $room->id);
+});


### PR DESCRIPTION
## Show currently active room in sidebar
![WhatsApp Image 2025-04-13 at 15 05 55_b7081459](https://github.com/user-attachments/assets/2a0f2393-7848-412c-8775-dd8c6265755f)
### for dark mode
![image](https://github.com/user-attachments/assets/cf5842ca-0d22-4182-80d0-8b4571a8b393)

