### PR TITLE
Make chat sidebar responsive for mobile screens

### DIFF
--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -1,4 +1,4 @@
-<div class="bg-white dark:bg-gray-800 w-3/4">
+<div class="bg-white dark:bg-gray-800 w-full md:w-3/4">
     <div class="container mx-auto px-4 py-4">
         <div class="flex justify-between items-center">
             <div class="flex items-center gap-3">

--- a/resources/views/livewire/rooms/index.blade.php
+++ b/resources/views/livewire/rooms/index.blade.php
@@ -2,7 +2,7 @@
     <div class="mx-auto px-4 py-4">
         <div class="flex justify-between items-center">
             <h1 class="hidden md:block text-2xl font-bold text-gray-800 dark:text-gray-100">Chats</h1>
-            <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-2 rounded-sm"
+            <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-1 md:py-2 md:px-2 rounded-sm"
                 x-on:click="$dispatch('open-modal', 'create-room')"
                 title="Create Room"
             >

--- a/resources/views/livewire/rooms/index.blade.php
+++ b/resources/views/livewire/rooms/index.blade.php
@@ -1,7 +1,7 @@
-<aside class="bg-white dark:bg-gray-800 w-1/4">
-    <div class="container mx-auto px-4 py-4">
+<aside class="bg-white dark:bg-gray-800 w-16 md:w-1/4  border-r border-gray-700">
+    <div class="mx-auto px-4 py-4">
         <div class="flex justify-between items-center">
-            <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">Chats</h1>
+            <h1 class="hidden md:block text-2xl font-bold text-gray-800 dark:text-gray-100">Chats</h1>
             <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-2 rounded-sm"
                 x-on:click="$dispatch('open-modal', 'create-room')"
                 title="Create Room"
@@ -27,7 +27,18 @@
         </div>
         <div
             class="mt-4 h-[calc(100vh-155px)] overflow-y-auto scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-gray-100">
-            <div class="flex flex-col gap-4">
+            <div class="flex justify-center md:hidden">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" 
+                @class([
+                    'size-8',
+                    'text-blue-500' => true,
+                    'text-white' => false,
+                ])
+                class="">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12c0 4.556-4.03 8.25-9 8.25a9.764 9.764 0 0 1-2.555-.337A5.972 5.972 0 0 1 5.41 20.97a5.969 5.969 0 0 1-.474-.065 4.48 4.48 0 0 0 .978-2.025c.09-.457-.133-.901-.467-1.226C3.93 16.178 3 14.189 3 12c0-4.556 4.03-8.25 9-8.25s9 3.694 9 8.25Z"></path>
+                </svg>
+            </div>            
+            <div class="hidden md:flex flex-col gap-4">
                 @forelse ($rooms as $room)
                     <div
                         @class([

--- a/resources/views/livewire/rooms/index.blade.php
+++ b/resources/views/livewire/rooms/index.blade.php
@@ -1,4 +1,4 @@
-<aside class="bg-white dark:bg-gray-800 w-16 md:w-1/4  border-r border-gray-700">
+<aside class="bg-white dark:bg-gray-800 w-16 md:w-1/4 border-r border-gray-700">
     <div class="mx-auto px-4 py-4">
         <div class="flex justify-between items-center">
             <h1 class="hidden md:block text-2xl font-bold text-gray-800 dark:text-gray-100">Chats</h1>


### PR DESCRIPTION
### 🐛 Before (Issue)
- The sidebar layout was not responsive on smaller or mobile screens.
- UI elements were overlapping, such as:
  - The **Create Model** button
  - The **Chat** heading
  - The **Room** tab (which remained open and cluttered the view)

![image](https://github.com/user-attachments/assets/80d64944-45b0-4b93-84e8-9477fd6eafb6)

### ✅ After (Fix)

- The sidebar layout has been optimized for mobile devices.
- Overlapping issues have been resolved.
- The interface now adjusts cleanly to different screen sizes.

![image](https://github.com/user-attachments/assets/46305192-9e97-4f3a-9ee0-9f1ac4976d89)

