### PR TITLE
fix: remove unused import for choices.js styles in app.css to fix bg-…

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,6 +1,5 @@
 @import 'tailwindcss';
 @import '../../vendor/livewire/flux/dist/flux.css';
-@import 'choices.js/public/assets/styles/base.css';
 
 @source '../views';
 @source '../../vendor/laravel/framework/src/Illuminate/Pagination/resources/views/*.blade.php';


### PR DESCRIPTION
This PR fixes text and background color issues for login, dashboard and profile pages, the reason for this visual bug is this unused import
```@import 'choices.js/public/assets/styles/base.css';```

### Login page
<img width="1872" height="969" alt="image" src="https://github.com/user-attachments/assets/d20d2726-f547-44a5-8356-536fb4742810" />

### Dashboard page
<img width="1904" height="969" alt="image" src="https://github.com/user-attachments/assets/12de1f27-90d4-4baf-90ed-b4bdad1f8650" />

### Profile Page
<img width="1916" height="945" alt="image" src="https://github.com/user-attachments/assets/99c40adb-a801-4932-8075-4cdc55d9d76d" />
