### PR TITLE
fix: detach favorite users when deleting a chat

### DIFF
--- a/app/Livewire/Chats/Show.php
+++ b/app/Livewire/Chats/Show.php
@@ -24,6 +24,7 @@ class Show extends Component
     public function delete(): void
     {
         abort_unless($this->isCurrentUser(), 403, 'You are not authorized to delete this chat.');
+
         $this->chat->favoriteUsers()->detach();
         $this->chat->touch('deleted_at');
         $this->dispatch('chat:deleted', chatId: $this->chat->id);

--- a/app/Livewire/Chats/Show.php
+++ b/app/Livewire/Chats/Show.php
@@ -24,6 +24,10 @@ class Show extends Component
     public function delete(): void
     {
         abort_unless($this->isCurrentUser(), 403, 'You are not authorized to delete this chat.');
+        if ($this->chat->favoriteUsers()->exists()) {
+            $this->chat->favoriteUsers()->detach();
+        }
+
         $this->chat->touch('deleted_at');
         $this->dispatch('chat:deleted', chatId: $this->chat->id);
 

--- a/app/Livewire/Chats/Show.php
+++ b/app/Livewire/Chats/Show.php
@@ -24,10 +24,7 @@ class Show extends Component
     public function delete(): void
     {
         abort_unless($this->isCurrentUser(), 403, 'You are not authorized to delete this chat.');
-        if ($this->chat->favoriteUsers()->exists()) {
-            $this->chat->favoriteUsers()->detach();
-        }
-
+        $this->chat->favoriteUsers()->detach();
         $this->chat->touch('deleted_at');
         $this->dispatch('chat:deleted', chatId: $this->chat->id);
 

--- a/storage/pail/.gitignore
+++ b/storage/pail/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/storage/pail/.gitignore
+++ b/storage/pail/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Unit/Livewire/Chats/ShowTest.php
+++ b/tests/Unit/Livewire/Chats/ShowTest.php
@@ -90,6 +90,23 @@ it('can delete', function (): void {
     Event::assertDispatched(ChatUpdated::class, fn (ChatUpdated $event): bool => $event->chatId === $chat->id && $event->roomId === $chat->room_id);
 });
 
+it('can delete chat which is marked as favorite by many users', function (): void {
+    $chat = Chat::factory()->create();
+    $chat->favoriteUsers()->attach(User::factory()->count(3)->create()->pluck('id'));
+
+    expect($chat->favoriteUsers()->count())->toBe(3);
+
+    Livewire::actingAs($chat->user)
+        ->test(Show::class, ['chat' => $chat])
+        ->call('delete')
+        ->assertDispatched('chat:deleted', chatId: $chat->id);
+
+    expect($chat->fresh()->deleted_at)->not()->toBeNull();
+    expect($chat->favoriteUsers()->count())->toBe(0);
+
+    Event::assertDispatched(ChatUpdated::class, fn (ChatUpdated $event): bool => $event->chatId === $chat->id && $event->roomId === $chat->room_id);
+});
+
 it('can not delete if the user is not the owner of the chat', function (): void {
     $chat = Chat::factory()->create();
 


### PR DESCRIPTION
### Summary

This PR fixes #49.

Previously, a chat could be deleted even when it was marked as a favorite by one or more users. In such cases, the related `favoriteUsers` records were left behind, resulting in orphaned relationships.

### Changes

- Detach all associated `favoriteUsers` from a chat before deleting it.
- Delete the chat only after its favorite user relationships have been removed.

### Result

Deleting a chat now properly cleans up its favorite user associations, ensuring referential integrity and preventing orphaned records.