### PR TITLE
Feat/add new members to room

### DIFF
--- a/app/Livewire/Pages/Chats.php
+++ b/app/Livewire/Pages/Chats.php
@@ -5,12 +5,26 @@ declare(strict_types=1);
 namespace App\Livewire\Pages;
 
 use Illuminate\View\View;
+use Livewire\Attributes\On;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 
 #[Title('Chats')]
 class Chats extends Component
 {
+
+    public bool $showRoomProfile = false;
+
+    public int $roomId;
+
+    #[On('show-room-profile')]
+    public function updateRoomProfile(int $roomId){
+        $this->showRoomProfile = $roomId ? true : false;
+        if($this->showRoomProfile){
+            $this->roomId = $roomId;
+        }
+    }
+
     public function render(): View
     {
         return view('livewire.pages.chats');

--- a/app/Livewire/Pages/Chats.php
+++ b/app/Livewire/Pages/Chats.php
@@ -17,10 +17,10 @@ class Chats extends Component
 
     public int $roomId;
 
-    #[On('show-room-profile')]
-    public function updateRoomProfile(int $roomId){
-        $this->showRoomProfile = $roomId ? true : false;
-        if($this->showRoomProfile){
+    #[On('toggle-room-profile')]
+    public function toggleShowRoomProfile(bool $showRoomProfile = false,int $roomId){
+        $this->showRoomProfile = $showRoomProfile;
+        if($showRoomProfile){
             $this->roomId = $roomId;
         }
     }

--- a/app/Livewire/Pages/Chats.php
+++ b/app/Livewire/Pages/Chats.php
@@ -12,15 +12,15 @@ use Livewire\Component;
 #[Title('Chats')]
 class Chats extends Component
 {
-
     public bool $showRoomProfile = false;
 
     public int $roomId;
 
     #[On('toggle-room-profile')]
-    public function toggleShowRoomProfile(bool $showRoomProfile = false,int $roomId){
+    public function toggleShowRoomProfile(bool $showRoomProfile = false, int $roomId = 0): void
+    {
         $this->showRoomProfile = $showRoomProfile;
-        if($showRoomProfile){
+        if ($showRoomProfile) {
             $this->roomId = $roomId;
         }
     }

--- a/app/Livewire/Rooms/AddMembers.php
+++ b/app/Livewire/Rooms/AddMembers.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Rooms;
 
 use App\Models\Room;
 use App\Models\User;
+use Flux\Flux;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
@@ -59,6 +60,7 @@ class AddMembers extends Component
         $this->room->users()->sync($this->members);
 
         $this->dispatch('members-added', id: $this->room->id);
+        Flux::toast(variant: 'success',text:"member(s) added to the group");
     }
 
     public function render(): Factory|View

--- a/app/Livewire/Rooms/AddMembers.php
+++ b/app/Livewire/Rooms/AddMembers.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Rooms;
+
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Component;
+
+class AddMembers extends Component
+{
+    public Room $room;
+
+    /**
+     * @var Collection<int, User>
+     */
+    public Collection $allUsers;
+
+    /**
+     * @var Collection<int, User>
+     */
+    public Collection $existingMembers;
+
+    /**
+     * @var array<array-key, int>
+     */
+    public array $members = [];
+
+    public function rules(): array
+    {
+        return [
+            'members' => ['array', 'min:'.$this->existingMembers->count()],
+            'members.*' => [
+                'required',
+                'exists:users,id',
+            ],
+        ];
+    }
+
+    public function mount(): void
+    {
+        $this->allUsers = User::query()
+            ->select(['id', 'name'])
+            ->orderBy('name')
+            ->get();
+
+        $this->members = $this->existingMembers
+            ->pluck('id')
+            ->all();
+    }
+
+    public function submit(): void
+    {
+        $this->validate();
+        $this->room->users()->sync($this->members);
+
+        $this->dispatch('members-added', id: $this->room->id);
+    }
+
+    public function render(): Factory|View
+    {
+        return view('livewire.rooms.add-members');
+    }
+}

--- a/app/Livewire/Rooms/AddMembers.php
+++ b/app/Livewire/Rooms/AddMembers.php
@@ -27,10 +27,13 @@ class AddMembers extends Component
     public Collection $existingMembers;
 
     /**
-     * @var array<array-key, int>
+     * @var array<int,int>
      */
     public array $members = [];
 
+    /**
+     * @return array<string,list<string>>
+     */
     public function rules(): array
     {
         return [
@@ -50,8 +53,7 @@ class AddMembers extends Component
             ->get();
 
         $this->members = $this->existingMembers
-            ->pluck('id')
-            ->all();
+            ->modelKeys();
     }
 
     public function submit(): void
@@ -60,7 +62,7 @@ class AddMembers extends Component
         $this->room->users()->sync($this->members);
 
         $this->dispatch('members-added', id: $this->room->id);
-        Flux::toast(variant: 'success',text:"member(s) added to the group");
+        Flux::toast(variant: 'success', text: 'member(s) added to the group');
     }
 
     public function render(): Factory|View

--- a/app/Livewire/Rooms/AddMembers.php
+++ b/app/Livewire/Rooms/AddMembers.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Rooms;
 
 use App\Models\Room;
 use App\Models\User;
+use Closure;
 use Flux\Flux;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
@@ -32,14 +33,30 @@ class AddMembers extends Component
     public array $members = [];
 
     /**
-     * @return array<string,list<string>>
+     * @return array<string, list<mixed>>
      */
     public function rules(): array
     {
         return [
-            'members' => ['array', 'min:'.$this->existingMembers->count()],
+            'members' => [
+                'array',
+                'min:'.$this->existingMembers->count(),
+                function (string $attribute, mixed $value, Closure $fail): void {
+
+                    /** @var list<int> $value */
+                    $removedMembers = array_diff(
+                        $this->existingMembers->modelKeys(),
+                        $value,
+                    );
+
+                    if ($removedMembers !== []) {
+                        $fail('Existing members cannot be removed.');
+                    }
+                },
+            ],
             'members.*' => [
                 'required',
+                'integer',
                 'exists:users,id',
             ],
         ];

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -5,31 +5,27 @@ declare(strict_types=1);
 namespace App\Livewire\Rooms;
 
 use App\Models\Room;
-use App\Models\User;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
+#[On('members-added')]
 class RoomProfile extends Component
 {
     public int $roomId;
 
     public Room $room;
 
-    /**
-     * @var Collection<int, User>
-     */
-    public Collection $existingMembers;
-
     public function mount(): void
     {
         $this->room = Room::query()->findOrFail($this->roomId);
-        $this->existingMembers = $this->room->users;
     }
 
     public function render(): Factory|View
     {
-        return view('livewire.rooms.room-profile');
+        return view('livewire.rooms.room-profile', [
+            'existingMembers' => $this->room->users,
+        ]);
     }
 }

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -1,24 +1,35 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Livewire\Rooms;
 
-use App\Models\Member;
 use App\Models\Room;
+use App\Models\User;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
-use Livewire\Attributes\On;
 use Livewire\Component;
 
 class RoomProfile extends Component
 {
     public int $roomId;
 
-    public function render()
+    public Room $room;
+
+    /**
+     * @var Collection<int, User>
+     */
+    public Collection $existingMembers;
+
+    public function mount(): void
     {
-        $room = Room::query()->findOrFail($this->roomId);
-        $members = $room->users;
-        return view('livewire.rooms.room-profile',[
-            'room' => $room,
-            'members' => $members
-        ]);
+        $this->room = Room::query()->findOrFail($this->roomId);
+        $this->existingMembers = $this->room->users;
+    }
+
+    public function render(): Factory|View
+    {
+        return view('livewire.rooms.room-profile');
     }
 }

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Rooms;
+
+use App\Models\Member;
+use App\Models\Room;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class RoomProfile extends Component
+{
+    public int $roomId;
+
+    public function render()
+    {
+        $room = Room::query()->findOrFail($this->roomId);
+        $members = $room->users;
+        return view('livewire.rooms.room-profile',[
+            'room' => $room,
+            'members' => $members
+        ]);
+    }
+}

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Rooms;
 use App\Models\Room;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -20,6 +21,8 @@ class RoomProfile extends Component
     public function mount(): void
     {
         $this->room = Room::query()->findOrFail($this->roomId);
+
+        abort_if(Gate::denies('show-roomProfile', $this->room), 403, 'You are not authorized to view this room profile.');
     }
 
     public function render(): Factory|View

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\Room;
+use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 use Override;
@@ -27,6 +30,9 @@ class AppServiceProvider extends ServiceProvider
     {
         Model::unguard();
         $this->configureDefaults();
+
+        Gate::define('show-roomProfile', fn (User $user, Room $room): bool => $room->user_id === $user->id
+            || (bool) $room->users()->whereKey($user->id)->exists());
     }
 
     /**

--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -18,7 +18,7 @@
                     >
                         <flux:icon.bars-3 class="size-5" />
                     </button>
-                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="$dispatch('show-room-profile')">
+                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="$dispatch('show-room-profile',{ roomId: {{ $room->id }} })">
                             <img
                                 src="{{ $room->user->profile }}"
                                 alt="{{ $room->user->name }}"
@@ -28,7 +28,7 @@
                         </figure>
                         <div class="min-w-0">
                             <h2
-                                x-on:click="$dispatch('show-room-profile')"
+                                x-on:click="$dispatch('show-room-profile',{ roomId: {{ $room->id }} })"
                                 class="cursor-pointer truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
                             <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
                         </div>

--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -18,7 +18,7 @@
                     >
                         <flux:icon.bars-3 class="size-5" />
                     </button>
-                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="$dispatch('show-room-profile',{ roomId: {{ $room->id }} })">
+                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="showRoomProfile = true; $dispatch('toggle-room-profile',{ showRoomProfile: true, roomId: {{ $room->id }} })">
                             <img
                                 src="{{ $room->user->profile }}"
                                 alt="{{ $room->user->name }}"
@@ -28,7 +28,7 @@
                         </figure>
                         <div class="min-w-0">
                             <h2
-                                x-on:click="$dispatch('show-room-profile',{ roomId: {{ $room->id }} })"
+                                x-on:click="showRoomProfile = true; $dispatch('toggle-room-profile',{ showRoomProfile: true, roomId: {{ $room->id }} })"
                                 class="cursor-pointer truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
                             <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
                         </div>

--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -18,20 +18,25 @@
                     >
                         <flux:icon.bars-3 class="size-5" />
                     </button>
-                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="showRoomProfile = true; $dispatch('toggle-room-profile',{ showRoomProfile: true, roomId: {{ $room->id }} })">
-                            <img
-                                src="{{ $room->user->profile }}"
-                                alt="{{ $room->user->name }}"
-                                class="size-10 w-full rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
-                            />
-                            <div class="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-zinc-800 rounded-full"></div>
-                        </figure>
-                        <div class="min-w-0">
-                            <h2
-                                x-on:click="showRoomProfile = true; $dispatch('toggle-room-profile',{ showRoomProfile: true, roomId: {{ $room->id }} })"
-                                class="cursor-pointer truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
-                            <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
-                        </div>
+                         <button
+                            type="button"
+                            class="flex min-w-0 items-center gap-4 cursor-pointer text-left"
+                            x-on:click="showRoomProfile = true; $dispatch('toggle-room-profile', { showRoomProfile: true, roomId: {{ $room->id }} })"
+                            aria-label="Show room info for {{ $room->name }}"
+                        >
+                            <figure class="relative size-10 shrink-0">
+                                <img
+                                    src="{{ $room->user->profile }}"
+                                    alt="{{ $room->user->name }}"
+                                    class="size-10 w-full rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
+                                />
+                                <div class="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-zinc-800 rounded-full"></div>
+                            </figure>
+                            <div class="min-w-0">
+                                <h2 class="truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
+                                <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
+                            </div>
+                        </button>
                 </div>
                 {{-- Chat filter options --}}
                 <div

--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -1,7 +1,10 @@
 @php
     use App\Enums\ChatFilterEnum;
 @endphp
-<div class="flex min-h-0 min-w-0 flex-1 flex-col bg-white dark:bg-zinc-800">
+<div
+    class="flex w-full min-h-0 flex-col bg-white dark:bg-zinc-800"
+    :class="showRoomProfile ? 'max-xl:hidden' : ''"
+>
     <!-- Chat Header -->
     <div class="flex-shrink-0 bg-white dark:bg-zinc-800 border-b border-zinc-200 dark:border-zinc-700 px-6 py-4">
         @if ($room !== null)
@@ -15,20 +18,20 @@
                     >
                         <flux:icon.bars-3 class="size-5" />
                     </button>
-                    <figure class="relative size-10 flex-shrink-0">
-                        <img
-                            src="{{ $room->user->profile }}"
-                            alt="{{ $room->user->name }}"
-                            class="size-10 rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
-                        />
-                        <div
-                            class="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-zinc-800 rounded-full">
+                        <figure  class="cursor-pointer relative size-10 shrink-0"  x-on:click="$dispatch('show-room-profile')">
+                            <img
+                                src="{{ $room->user->profile }}"
+                                alt="{{ $room->user->name }}"
+                                class="size-10 w-full rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
+                            />
+                            <div class="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-400 border-2 border-white dark:border-zinc-800 rounded-full"></div>
+                        </figure>
+                        <div class="min-w-0">
+                            <h2
+                                x-on:click="$dispatch('show-room-profile')"
+                                class="cursor-pointer truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
+                            <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
                         </div>
-                    </figure>
-                    <div class="min-w-0">
-                        <h2 class="truncate text-xl font-semibold text-zinc-900 dark:text-zinc-100">{{ $room->name }}</h2>
-                        <p class="text-sm text-zinc-500 dark:text-zinc-400">Active now</p>
-                    </div>
                 </div>
                 {{-- Chat filter options --}}
                 <div

--- a/resources/views/livewire/pages/chats.blade.php
+++ b/resources/views/livewire/pages/chats.blade.php
@@ -4,7 +4,7 @@
     x-on:open-rooms.window="roomsOpen = true"
     x-on:close-rooms.window="roomsOpen = false"
     x-on:room-selected.window="roomsOpen = false"
-    x-on:keydown.escape.window="roomsOpen = false; showRoomProfile = false"
+    x-on:keydown.escape.window="roomsOpen = false; showRoomProfile = false;"
     x-on:show-room-profile.window="showRoomProfile = true"
 >
     <div
@@ -20,83 +20,7 @@
     <livewire:chats />
 
     {{-- Room Profile sidebar - Right --}}
-    <section  class="
-        overflow-y-auto
-        transition-all
-        duration-300
-        bg-white
-        dark:bg-zinc-800
-        border-l
-        border-zinc-700
-        xl:max-w-lg
-        flex-col
-    "
-    :class="showRoomProfile
-        ? 'w-full max-w-full flex'
-        : 'w-0'"
-    x-cloak
-    >
-        <header class="flex items-center gap-4 px-6 py-5 border-b border-zinc-200 dark:border-zinc-700">
-            <flux:button x-on:click="showRoomProfile = false" icon="x-mark" icon:variant="outline" variant="subtle" />
-            <flux:heading variant="strong">Room info</flux:heading>
-            <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
-        </header>
-        <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
-            <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
-                <div>
-                    <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
-                        class="w-28 h-28 rounded-full object-cover" alt="" />
-                </div>
-                <h1 class="text-lg md:text-2xl">Laragang</h1>
-                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-400">About</p>
-                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-200">Official chat account of laragang</p>
-            </div>
-
-            <flux:separator class="my-5"/>
-
-
-            {{--show members list --}}
-            <div class="w-full space-y-1">
-                <div class="mb-2 flex items-center justify-between w-full">
-                    <flux:text>11 members</flux:text>
-                    <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
-                </div>
-
-                <ul class="flex flex-col gap-5">
-                    <li class="flex gap-4 items-center">
-                        {{-- image --}}
-                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
-
-                        <div>
-                            {{-- name --}}
-                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
-                            {{-- bio --}}
-                            <flux:text>Good is not good when better is possible</flux:text>
-                        </div>
-                    </li>
-                    <li class="flex gap-4 items-center">
-                        {{-- image --}}
-                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
-
-                        <div>
-                            {{-- name --}}
-                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
-                            {{-- bio --}}
-                            <flux:text>Good is not good when better is possible</flux:text>
-                        </div>
-                    </li><li class="flex gap-4 items-center">
-                        {{-- image --}}
-                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
-
-                        <div>
-                            {{-- name --}}
-                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
-                            {{-- bio --}}
-                            <flux:text>Good is not good when better is possible</flux:text>
-                        </div>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </section>
+    @if ($this->showRoomProfile)
+        <livewire:rooms.room-profile :$roomId lazy />
+    @endif
 </div>

--- a/resources/views/livewire/pages/chats.blade.php
+++ b/resources/views/livewire/pages/chats.blade.php
@@ -4,7 +4,7 @@
     x-on:open-rooms.window="roomsOpen = true"
     x-on:close-rooms.window="roomsOpen = false"
     x-on:room-selected.window="roomsOpen = false"
-    x-on:keydown.escape.window="roomsOpen = false; showRoomProfile = false;"
+    x-on:keydown.escape.window="roomsOpen = false; showRoomProfile = false; $dispatch('toggle-room-profile',{ showRoomProfile: false, roomId: 0 })"
     x-on:show-room-profile.window="showRoomProfile = true"
 >
     <div
@@ -20,7 +20,25 @@
     <livewire:chats />
 
     {{-- Room Profile sidebar - Right --}}
-    @if ($this->showRoomProfile)
-        <livewire:rooms.room-profile :$roomId lazy />
-    @endif
+    <section
+            class="
+                overflow-y-auto
+                transition-all
+                duration-300
+                bg-white
+                dark:bg-zinc-800
+                border-l
+                dark:border-zinc-700
+                xl:max-w-lg
+                flex-col
+            "
+            :class="showRoomProfile
+                ? 'w-full max-w-full flex'
+                : 'w-0'"
+            x-cloak
+        >
+        @if ($this->showRoomProfile)
+            <livewire:rooms.room-profile :$roomId lazy />
+        @endif
+    </section>
 </div>

--- a/resources/views/livewire/pages/chats.blade.php
+++ b/resources/views/livewire/pages/chats.blade.php
@@ -1,10 +1,11 @@
 <div
     class="relative flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-white dark:bg-zinc-900"
-    x-data="{ roomsOpen: false }"
+    x-data="{ roomsOpen: false, showRoomProfile: false }"
     x-on:open-rooms.window="roomsOpen = true"
     x-on:close-rooms.window="roomsOpen = false"
     x-on:room-selected.window="roomsOpen = false"
-    x-on:keydown.escape.window="roomsOpen = false"
+    x-on:keydown.escape.window="roomsOpen = false; showRoomProfile = false"
+    x-on:show-room-profile.window="showRoomProfile = true"
 >
     <div
         class="fixed inset-0 z-40 bg-zinc-950/50 lg:hidden"
@@ -17,4 +18,85 @@
     <livewire:rooms />
 
     <livewire:chats />
+
+    {{-- Room Profile sidebar - Right --}}
+    <section  class="
+        overflow-y-auto
+        transition-all
+        duration-300
+        bg-white
+        dark:bg-zinc-800
+        border-l
+        border-zinc-700
+        xl:max-w-lg
+        flex-col
+    "
+    :class="showRoomProfile
+        ? 'w-full max-w-full flex'
+        : 'w-0'"
+    x-cloak
+    >
+        <header class="flex items-center gap-4 px-6 py-5 border-b border-zinc-200 dark:border-zinc-700">
+            <flux:button x-on:click="showRoomProfile = false" icon="x-mark" icon:variant="outline" variant="subtle" />
+            <flux:heading variant="strong">Room info</flux:heading>
+            <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
+        </header>
+        <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
+            <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
+                <div>
+                    <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
+                        class="w-28 h-28 rounded-full object-cover" alt="" />
+                </div>
+                <h1 class="text-lg md:text-2xl">Laragang</h1>
+                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-400">About</p>
+                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-200">Official chat account of laragang</p>
+            </div>
+
+            <flux:separator class="my-5"/>
+
+
+            {{--show members list --}}
+            <div class="w-full space-y-1">
+                <div class="mb-2 flex items-center justify-between w-full">
+                    <flux:text>11 members</flux:text>
+                    <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
+                </div>
+
+                <ul class="flex flex-col gap-5">
+                    <li class="flex gap-4 items-center">
+                        {{-- image --}}
+                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
+
+                        <div>
+                            {{-- name --}}
+                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
+                            {{-- bio --}}
+                            <flux:text>Good is not good when better is possible</flux:text>
+                        </div>
+                    </li>
+                    <li class="flex gap-4 items-center">
+                        {{-- image --}}
+                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
+
+                        <div>
+                            {{-- name --}}
+                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
+                            {{-- bio --}}
+                            <flux:text>Good is not good when better is possible</flux:text>
+                        </div>
+                    </li><li class="flex gap-4 items-center">
+                        {{-- image --}}
+                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name=parthil&color=7F9CF5&background=EBF4FF" alt="">
+
+                        <div>
+                            {{-- name --}}
+                            <flux:text variant="strong" class="text-base">Parthil Patel</flux:text>
+                            {{-- bio --}}
+                            <flux:text>Good is not good when better is possible</flux:text>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </section>
 </div>

--- a/resources/views/livewire/rooms/add-members.blade.php
+++ b/resources/views/livewire/rooms/add-members.blade.php
@@ -1,0 +1,54 @@
+<div>
+    <form wire:submit="submit" class="space-y-4">
+        <div class="flex items-center gap-3">
+            <div
+                class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-500/15 dark:text-blue-300">
+                <flux:icon.user-plus class="size-5" />
+            </div>
+
+            <div class="min-w-0">
+                <flux:heading size="lg">{{ __('Add member') }}</flux:heading>
+            </div>
+        </div>
+
+        <flux:separator />
+
+        <flux:text>All Users</flux:text>
+
+        <flux:error name="members" />
+
+        <flux:checkbox.group wire:model="members" variant="cards" class="flex-col overflow-y-auto h-75">
+            @foreach ($allUsers as $user)
+                @php
+                    $isMember = $existingMembers->contains($user);
+                @endphp
+                <flux:checkbox class="flex gap-6 items-center justify-normal cursor-pointer p-2!" :value="$user->id"
+                    :disabled="$isMember">
+                    <flux:checkbox.indicator />
+                    <div class="flex gap-2 items-center">
+                        {{-- image --}}
+                        <img class="size-10 rounded-full "
+                            src="https://ui-avatars.com/api/?name={{ $user->name }}&color=7F9CF5&background=EBF4FF"
+                            alt="{{ $user->name }} avatar">
+
+                        <div>
+                            {{-- name --}}
+                            <flux:text variant="strong" class="text-base">{{ $user->name }}</flux:text>
+                            <flux:text wire:show="{{ $isMember }}" variant="subtle" class="text-sm">Already
+                                added to the group</flux:text>
+                        </div>
+
+                    </div>
+                </flux:checkbox>
+            @endforeach
+        </flux:checkbox.group>
+
+
+        <flux:button
+            type="submit"
+            variant="primary"
+            class="w-full rounded-full">
+            {{ __('Add member') }}
+        </flux:button>
+    </form>
+</div>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -42,7 +42,7 @@
                         <div>
                             {{-- name --}}
                             <flux:text variant="strong" class="text-base">{{ $member->name }}</flux:text>
-                            {{-- bio --}}
+                            {{-- bio @TODO add bio field in user profile --}}
                             <flux:text>{{ $member?->bio ?: '--' }}</flux:text>
                         </div>
                     </li>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -1,50 +1,37 @@
-   <section  class="
-        overflow-y-auto
-        transition-all
-        duration-300
-        bg-white
-        dark:bg-zinc-800
-        border-l
-        dark:border-zinc-700
-        xl:max-w-lg
-        flex-col
-    "
-    :class="showRoomProfile
-        ? 'w-full max-w-full flex'
-        : 'w-0'"
-    x-cloak
-    >
-        <header class="flex items-center gap-4 px-6 py-5 border-b border-zinc-200 dark:border-zinc-700">
-            <flux:button x-on:click="$dispatch('show-room-profile',{roomId: 0}) ;showRoomProfile = false" icon="x-mark" icon:variant="outline" variant="subtle" />
-            <flux:heading variant="strong">Room info</flux:heading>
-            <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
-        </header>
-        <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
-            <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
-                <div>
-                    <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
-                        class="w-28 h-28 rounded-full object-cover" alt="" />
-                </div>
-                <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>
-                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-400">About</p>
-                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-200">{{ $room->description ?: '--'  }}</p>
+<div>
+    <header class="flex items-center gap-4 px-6 py-5 border-b border-zinc-200 dark:border-zinc-700">
+            <flux:button x-on:click="showRoomProfile = false; $dispatch('toggle-room-profile',{ showRoomProfile: false, roomId: 0 })" icon="x-mark" icon:variant="outline" variant="subtle" />
+        <flux:heading variant="strong">Room info</flux:heading>
+        <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
+    </header>
+    <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
+        <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
+            <div>
+                <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
+                    class="w-28 h-28 rounded-full object-cover" alt="" />
+            </div>
+            <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>
+            <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-400">About</p>
+            <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-200">{{ $room->description ?: '--' }}</p>
+        </div>
+
+        <flux:separator class="my-5" />
+
+
+        {{-- show members list --}}
+        <div class="w-full space-y-1">
+            <div class="mb-2 flex items-center justify-between w-full">
+                <flux:text>{{ $room->users->count() }} members</flux:text>
+                <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
             </div>
 
-            <flux:separator class="my-5"/>
-
-
-            {{--show members list --}}
-            <div class="w-full space-y-1">
-                <div class="mb-2 flex items-center justify-between w-full">
-                    <flux:text>{{ $room->users->count()}} members</flux:text>
-                    <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
-                </div>
-
-                <ul class="flex flex-col gap-5">
-                    @forelse($members as $member)
+            <ul class="flex flex-col gap-5">
+                @forelse($members as $member)
                     <li class="flex gap-4 items-center">
                         {{-- image --}}
-                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name={{ $member->name }}&color=7F9CF5&background=EBF4FF" alt="">
+                        <img class="size-12 rounded-full "
+                            src="https://ui-avatars.com/api/?name={{ $member->name }}&color=7F9CF5&background=EBF4FF"
+                            alt="">
 
                         <div>
                             {{-- name --}}
@@ -53,12 +40,12 @@
                             <flux:text>{{ $member?->bio ?: '--' }}</flux:text>
                         </div>
                     </li>
-                    @empty
+                @empty
                     <div>
                         <flux:text>No members exists</flux:text>
                     </div>
-                    @endforelse
-                </ul>
-            </div>
+                @endforelse
+            </ul>
         </div>
-    </section>
+    </div>
+</div>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -24,9 +24,15 @@
                 <flux:text>{{ $room->users->count() }} members</flux:text>
                 <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
             </div>
-
+            <div class="w-full mb-3">
+                <flux:modal.trigger name="add-members">
+                    <flux:button icon="user-plus" variant="ghost" class="shrink-0 w-full justify-start! cursor-pointer">
+                        {{ __('Add member') }}
+                    </flux:button>
+                </flux:modal.trigger>
+            </div>
             <ul class="flex flex-col gap-5">
-                @forelse($members as $member)
+                @forelse($existingMembers as $member)
                     <li class="flex gap-4 items-center">
                         {{-- image --}}
                         <img class="size-12 rounded-full "
@@ -48,4 +54,13 @@
             </ul>
         </div>
     </div>
+
+    {{-- add members model --}}
+        <flux:modal
+            name="add-members"
+            class="w-full max-w-lg"
+            x-on:members-added.window="$dispatch('modal-close', { name: 'add-members' })"
+        >
+            <livewire:rooms.add-members :$existingMembers :$room />
+        </flux:modal>
 </div>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -1,0 +1,64 @@
+   <section  class="
+        overflow-y-auto
+        transition-all
+        duration-300
+        bg-white
+        dark:bg-zinc-800
+        border-l
+        dark:border-zinc-700
+        xl:max-w-lg
+        flex-col
+    "
+    :class="showRoomProfile
+        ? 'w-full max-w-full flex'
+        : 'w-0'"
+    x-cloak
+    >
+        <header class="flex items-center gap-4 px-6 py-5 border-b border-zinc-200 dark:border-zinc-700">
+            <flux:button x-on:click="$dispatch('show-room-profile',{roomId: 0}) ;showRoomProfile = false" icon="x-mark" icon:variant="outline" variant="subtle" />
+            <flux:heading variant="strong">Room info</flux:heading>
+            <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
+        </header>
+        <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
+            <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
+                <div>
+                    <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
+                        class="w-28 h-28 rounded-full object-cover" alt="" />
+                </div>
+                <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>
+                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-400">About</p>
+                <p class="text-sm md:text-base text-zinc-500 dark:text-zinc-200">{{ $room->description ?: '--'  }}</p>
+            </div>
+
+            <flux:separator class="my-5"/>
+
+
+            {{--show members list --}}
+            <div class="w-full space-y-1">
+                <div class="mb-2 flex items-center justify-between w-full">
+                    <flux:text>{{ $room->users->count()}} members</flux:text>
+                    <flux:button icon="magnifying-glass" icon:variant="outline" variant="subtle" />
+                </div>
+
+                <ul class="flex flex-col gap-5">
+                    @forelse($members as $member)
+                    <li class="flex gap-4 items-center">
+                        {{-- image --}}
+                        <img class="size-12 rounded-full " src="https://ui-avatars.com/api/?name={{ $member->name }}&color=7F9CF5&background=EBF4FF" alt="">
+
+                        <div>
+                            {{-- name --}}
+                            <flux:text variant="strong" class="text-base">{{ $member->name }}</flux:text>
+                            {{-- bio --}}
+                            <flux:text>{{ $member?->bio ?: '--' }}</flux:text>
+                        </div>
+                    </li>
+                    @empty
+                    <div>
+                        <flux:text>No members exists</flux:text>
+                    </div>
+                    @endforelse
+                </ul>
+            </div>
+        </div>
+    </section>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -36,8 +36,8 @@
                     <li class="flex gap-4 items-center">
                         {{-- image --}}
                         <img class="size-12 rounded-full "
-                            src="https://ui-avatars.com/api/?name={{ $member->name }}&color=7F9CF5&background=EBF4FF"
-                            alt="">
+                            src="{{ $member->profile }}"
+                            alt="{{ $member->name }}">
 
                         <div>
                             {{-- name --}}

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -7,7 +7,7 @@
     <div class="p-4 dark:border-zinc-700 flex flex-col items-center space-y-2 h-full">
         <div class="flex flex-col items-center w-full lg:max-w-md mx-auto space-y-2">
             <div>
-                <img src="https://images.pexels.com/photos/34598816/pexels-photo-34598816.png"
+                <img src="{{ $room->user->profile }}"
                     class="w-28 h-28 rounded-full object-cover" alt="" />
             </div>
             <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>

--- a/tests/Feature/AddMembersTest.php
+++ b/tests/Feature/AddMembersTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Rooms\AddMembers;
+use App\Models\Room;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('user can add new members to the room', function (): void {
+
+    $user = User::factory()->create();
+
+    $room = Room::factory()
+        ->for($user, relationship: 'user')
+        ->hasAttached(User::factory(3)->create(), relationship: 'users')
+        ->create();
+
+    expect($room->users->count())->toBe(3);
+
+    $newMembers = User::factory(2)->create();
+
+    $existingMemberIds = array_merge($room->users->pluck('id')->toArray(), [$room->user->id]);
+
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->set('members', [
+            ...$existingMemberIds,
+            ...$newMembers->pluck('id')->all(),
+        ])
+        ->call('submit')
+        ->assertHasNoErrors()
+        ->assertDispatched('members-added');
+
+    expect($room->users()->count())->toBe(6);
+
+    $this->assertDatabaseHas('members', ['user_id' => $newMembers->first()->id, 'room_id' => $room->id]);
+    $this->assertDatabaseHas('members', ['user_id' => $newMembers->last()->id, 'room_id' => $room->id]);
+});

--- a/tests/Feature/ChatsTest.php
+++ b/tests/Feature/ChatsTest.php
@@ -7,8 +7,10 @@ use App\Livewire\Chats\Save as CreateChat;
 use App\Livewire\Pages\Chats;
 use App\Livewire\Rooms\Create as CreateRoom;
 use App\Livewire\Rooms\Index as RoomsIndex;
+use App\Livewire\Rooms\RoomProfile;
 use App\Models\Room;
 use App\Models\User;
+use Livewire\Livewire;
 
 test('chats page is displayed', function (): void {
     $user = User::factory()->create();
@@ -20,6 +22,7 @@ test('chats page is displayed', function (): void {
         ->assertSeeLivewire(RoomsIndex::class)
         ->assertSeeLivewire(CreateRoom::class)
         ->assertDontSeeLivewire(CreateChat::class)
+        ->assertDontSeeLivewire(RoomProfile::class)
         ->assertOk();
 });
 
@@ -37,4 +40,41 @@ test('create chat component should be there if room is selected', function (): v
         ->assertSeeLivewire(CreateRoom::class)
         ->assertSeeLivewire(CreateChat::class)
         ->assertOk();
+});
+
+test('room profile component does not appear by default', function (): void {
+
+    $user = User::factory()->create();
+    $room = Room::factory()
+        ->hasAttached($user, relationship: 'users')
+        ->create();
+
+    $this->actingAs($user)
+        ->get('/chats?roomId='.$room->id)
+        ->assertSeeLivewire(Chats::class)
+        ->assertSeeLivewire(ChatsIndex::class)
+        ->assertSeeLivewire(RoomsIndex::class)
+        ->assertSeeLivewire(CreateRoom::class)
+        ->assertSeeLivewire(CreateChat::class)
+        ->assertDontSeeLivewire(RoomProfile::class)
+        ->assertOk();
+});
+
+test('toggle room profile component', function (): void {
+    $user = User::factory()->create();
+    $room = Room::factory()
+        ->hasAttached($user, relationship: 'users')
+        ->create();
+
+    Livewire::actingAs($user)
+        ->test(Chats::class, ['roomId' => $room->id])
+        ->assertSet('showRoomProfile', false)
+        ->dispatch('toggle-room-profile', showRoomProfile: true, roomId : $room->id)
+        ->assertSet('showRoomProfile', true)
+        ->assertSet('roomId', $room->id)
+        ->assertSeeLivewire(RoomProfile::class)
+        ->dispatch('toggle-room-profile', showRoomProfile: false, roomId : $room->id)
+        ->assertSet('showRoomProfile', false)
+        ->assertSet('roomId', $room->id)
+        ->assertDontSeeLivewire(RoomProfile::class);
 });

--- a/tests/Unit/Livewire/Rooms/AddMembersTest.php
+++ b/tests/Unit/Livewire/Rooms/AddMembersTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Rooms\AddMembers;
+use App\Models\Room;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('can render add member component', function (): void {
+    $room = Room::factory()
+        ->hasAttached(User::factory()->create(), relationship: 'users')
+        ->hasAttached(User::factory(3)->create(), relationship: 'users')
+        ->create();
+
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->assertStatus(200)
+        ->assertSee('Add member')
+        ->assertSee($room->users->first()->name)
+        ->assertSee($room->users->last()->name)
+        ->assertViewIs('livewire.rooms.add-members');
+});
+
+it('validates the members field', function (): void {
+    $user = User::factory()->create();
+    $room = Room::factory()
+        ->hasAttached(User::factory(3)->create(), relationship: 'users')
+        ->create();
+
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->set('members', [])
+        ->call('submit')
+        ->assertHasErrors(['members']);
+
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->set('members', [999])
+        ->call('submit')
+        ->assertHasErrors(['members.*']);
+
+    $existingMemberIds = array_merge($room->users->pluck('id')->toArray(), [$room->user->id]);
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->set('members', $existingMemberIds)
+        ->call('submit')
+        ->assertHasNoErrors();
+});

--- a/tests/Unit/Livewire/Rooms/AddMembersTest.php
+++ b/tests/Unit/Livewire/Rooms/AddMembersTest.php
@@ -22,7 +22,6 @@ it('can render add member component', function (): void {
 });
 
 it('validates the members field', function (): void {
-    $user = User::factory()->create();
     $room = Room::factory()
         ->hasAttached(User::factory(3)->create(), relationship: 'users')
         ->create();

--- a/tests/Unit/Livewire/Rooms/AddMembersTest.php
+++ b/tests/Unit/Livewire/Rooms/AddMembersTest.php
@@ -41,4 +41,13 @@ it('validates the members field', function (): void {
         ->set('members', $existingMemberIds)
         ->call('submit')
         ->assertHasNoErrors();
+
+    // silently replacing existing member by other user
+
+    $otherUser = User::factory()->create();
+    $existingMemberIds = array_merge($room->users->take(2)->pluck('id')->toArray(), [$otherUser->id], [$room->user->id]);
+    Livewire::test(AddMembers::class, ['room' => $room, 'existingMembers' => $room->users])
+        ->set('members', $existingMemberIds)
+        ->call('submit')
+        ->assertHasErrors(['members']);
 });

--- a/tests/Unit/Livewire/Rooms/RoomProfileTest.php
+++ b/tests/Unit/Livewire/Rooms/RoomProfileTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Rooms\RoomProfile;
+use App\Models\Room;
+use App\Models\User;
+use Livewire\Livewire;
+
+it('room profile renders room detail with members', function (): void {
+    $room = Room::factory()
+        ->hasAttached(User::factory()->create(), relationship: 'users')
+        ->hasAttached(User::factory(3)->create(), relationship: 'users')
+        ->create(['name' => 'Test Room']);
+
+    Livewire::test(RoomProfile::class, ['roomId' => $room->id])
+        ->assertStatus(200)
+        ->assertSee('Room info')
+        ->assertSee('Test Room')
+        ->assertSee($room->users->count().' members')
+        ->assertSee($room->user->name)
+        ->assertViewIs('livewire.rooms.room-profile');
+});

--- a/tests/Unit/Livewire/Rooms/RoomProfileTest.php
+++ b/tests/Unit/Livewire/Rooms/RoomProfileTest.php
@@ -7,17 +7,29 @@ use App\Models\Room;
 use App\Models\User;
 use Livewire\Livewire;
 
-it('room profile renders room detail with members', function (): void {
+test('room profile renders room detail with members', function (): void {
     $room = Room::factory()
-        ->hasAttached(User::factory()->create(), relationship: 'users')
         ->hasAttached(User::factory(3)->create(), relationship: 'users')
         ->create(['name' => 'Test Room']);
 
-    Livewire::test(RoomProfile::class, ['roomId' => $room->id])
+    Livewire::actingAs($room->user)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
         ->assertStatus(200)
         ->assertSee('Room info')
         ->assertSee('Test Room')
         ->assertSee($room->users->count().' members')
         ->assertSee($room->user->name)
         ->assertViewIs('livewire.rooms.room-profile');
+});
+
+test('room profile denies access for unauthorized users', function (): void {
+    $room = Room::factory()
+        ->hasAttached(User::factory()->create(), relationship: 'users')
+        ->create();
+
+    $otherUser = User::factory()->create();
+
+    Livewire::actingAs($otherUser)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
+        ->assertStatus(403);
 });


### PR DESCRIPTION
## Summary

Adds a room profile sidebar to the chats page and allows users to add new members to a room from that sidebar.

[Screencast from 2026-06-30 20-11-06.webm](https://github.com/user-attachments/assets/f25cea67-b947-4483-a99b-f096a5a8c0e1)


## What Changed

- added a `RoomProfile` Livewire component to display room details and current members
- added an `AddMembers` Livewire component with validation and member syncing
- wired the chats page to toggle the room profile sidebar via Livewire/Alpine events
- updated the chat header so clicking the room avatar or room name opens the profile panel
- refreshed the room profile after members are added and showed a success toast
- used dynamic room/user image URLs in the profile UI

## Testing

- added feature coverage for:
  - adding new members to a room
  - room profile visibility on the chats page
  - toggling the room profile component
- added Livewire component tests for:
  - rendering the add-members component
  - validating selected members
  - rendering room profile details and member count

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a room profile sidebar accessible from the chat header.
  * Room profiles show room details, description, member count, and member list.
  * Added an “Add member” workflow to invite additional users, with validation and success feedback.
  * Access to room profiles is restricted to authorized users.
* **Bug Fixes**
  * Improved responsive behavior by hiding the chat pane on smaller screens while the profile is open.
  * Added Escape-key and close controls to dismiss the profile sidebar.
* **Tests**
  * Added/extended coverage for room profile visibility and member-adding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->