### PR TITLE
feat(rooms): add room image uploads and inline description editing

### DIFF
--- a/app/Livewire/Chats/Index.php
+++ b/app/Livewire/Chats/Index.php
@@ -108,6 +108,16 @@ class Index extends Component
             ->get();
     }
 
+    #[On('room-updated')]
+    public function refreshRoom(int $roomId): void
+    {
+        if ($this->roomId !== $roomId) {
+            return;
+        }
+
+        unset($this->room);
+    }
+
     public function render(): View
     {
         return view('livewire.chats.index', [

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -5,24 +5,63 @@ declare(strict_types=1);
 namespace App\Livewire\Rooms;
 
 use App\Models\Room;
+use Flux\Flux;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\On;
+use Livewire\Attributes\Validate;
 use Livewire\Component;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Livewire\WithFileUploads;
 
 #[On('members-added')]
 class RoomProfile extends Component
 {
+    use WithFileUploads;
+
     public int $roomId;
 
     public Room $room;
+
+    #[Validate('nullable|image|mimes:jpeg,jpg,png,webp,gif|max:2048')]
+    public ?TemporaryUploadedFile $image = null;
 
     public function mount(): void
     {
         $this->room = Room::query()->findOrFail($this->roomId);
 
         abort_if(Gate::denies('show-roomProfile', $this->room), 403, 'You are not authorized to view this room profile.');
+    }
+
+    public function updatedImage(): void
+    {
+        $this->validateOnly('image');
+
+        $image = $this->image;
+
+        if (! $image instanceof TemporaryUploadedFile) {
+            return;
+        }
+
+        $existingImage = $this->room->getRawOriginal('image');
+
+        if (is_string($existingImage) && $existingImage !== '') {
+            Storage::disk('public')->delete($existingImage);
+        }
+
+        $path = $image->store('room/'.$this->roomId, 'public');
+
+        $this->room->update([
+            'image' => $path,
+        ]);
+
+        $this->image = null;
+
+        Flux::toast(variant: 'success', text: 'Room image updated successfully.');
+
+        $this->dispatch('room-updated', roomId: $this->roomId);
     }
 
     public function render(): Factory|View

--- a/app/Livewire/Rooms/RoomProfile.php
+++ b/app/Livewire/Rooms/RoomProfile.php
@@ -25,6 +25,8 @@ class RoomProfile extends Component
 
     public Room $room;
 
+    public ?string $description = null;
+
     #[Validate('nullable|image|mimes:jpeg,jpg,png,webp,gif|max:2048')]
     public ?TemporaryUploadedFile $image = null;
 
@@ -33,6 +35,8 @@ class RoomProfile extends Component
         $this->room = Room::query()->findOrFail($this->roomId);
 
         abort_if(Gate::denies('show-roomProfile', $this->room), 403, 'You are not authorized to view this room profile.');
+
+        $this->description = $this->room->description;
     }
 
     public function updatedImage(): void
@@ -62,6 +66,25 @@ class RoomProfile extends Component
         Flux::toast(variant: 'success', text: 'Room image updated successfully.');
 
         $this->dispatch('room-updated', roomId: $this->roomId);
+    }
+
+    public function saveDescription(): void
+    {
+        $this->validate([
+            'description' => 'nullable|string|max:2000',
+        ]);
+
+        $this->room->update([
+            'description' => (in_array($this->description, [null, '', '0'], true)) ? null : trim($this->description),
+        ]);
+
+        Flux::toast(variant: 'success', text: 'Room description changed.');
+
+        $this->dispatch(
+            'description-saved',
+            roomId: $this->roomId,
+            description: $this->room->description,
+        );
     }
 
     public function render(): Factory|View

--- a/app/Livewire/Rooms/Show.php
+++ b/app/Livewire/Rooms/Show.php
@@ -6,11 +6,22 @@ namespace App\Livewire\Rooms;
 
 use App\Models\Room;
 use Illuminate\View\View;
+use Livewire\Attributes\On;
 use Livewire\Component;
 
 class Show extends Component
 {
     public Room $room;
+
+    #[On('room-updated')]
+    public function refreshRoom(int $roomId): void
+    {
+        if ($this->room->id !== $roomId) {
+            return;
+        }
+
+        $this->room->refresh();
+    }
 
     public function render(): View
     {

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Database\Factories\RoomFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -17,6 +18,7 @@ use Illuminate\Support\Carbon;
  * @property int $id
  * @property string $name
  * @property string|null $description
+ * @property string|null $image
  * @property int $user_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -57,5 +59,21 @@ class Room extends Model
     public function chats(): HasMany
     {
         return $this->hasMany(Chat::class);
+    }
+
+    /**
+     * @return Attribute<string, never>
+     */
+    protected function image(): Attribute
+    {
+        return Attribute::get(
+            function (mixed $value): string {
+                if (! is_string($value) || $value === '') {
+                    return $this->user->profile;
+                }
+
+                return $value;
+            }
+        );
     }
 }

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -26,6 +26,7 @@ class RoomFactory extends Factory
             'name' => $this->faker->name,
             'description' => $this->faker->text,
             'user_id' => User::factory(),
+            'image' => null,
         ];
     }
 }

--- a/database/migrations/2026_09_04_112235_add_image_column_to_rooms_table.php
+++ b/database/migrations/2026_09_04_112235_add_image_column_to_rooms_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('rooms', function (Blueprint $table): void {
+            $table->string('image')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('rooms', function (Blueprint $table): void {
+            $table->dropColumn('image');
+        });
+    }
+};

--- a/resources/views/livewire/chats/index.blade.php
+++ b/resources/views/livewire/chats/index.blade.php
@@ -8,7 +8,7 @@
 >
     <div class="flex min-h-0 flex-1 flex-col bg-white dark:bg-zinc-800">
         <!-- Chat Header -->
-        <div class="flex-shrink-0 border-b border-zinc-200 bg-white px-6 py-4 dark:border-zinc-700 dark:bg-zinc-800">
+        <div class="shrink-0 border-b border-zinc-200 bg-white px-6 py-4 dark:border-zinc-700 dark:bg-zinc-800">
             @if ($room !== null)
                 <div class="flex items-center justify-between gap-4">
                     <div class="flex min-w-0 items-center gap-4">
@@ -29,8 +29,8 @@
                         >
                             <figure class="relative size-10 shrink-0">
                                 <img
-                                    src="{{ $room->user->profile }}"
-                                    alt="{{ $room->user->name }}"
+                                    src="{{ $room->image }}"
+                                    alt="{{ $room->name }}"
                                     class="size-10 w-full rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
                                 />
                                 <div class="absolute -right-0.5 -bottom-0.5 h-3 w-3 rounded-full border-2 border-white bg-green-400 dark:border-zinc-800"></div>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -2,16 +2,67 @@
     <header class="flex items-center gap-4 border-b border-zinc-200 px-6 py-5 dark:border-zinc-700">
         <flux:button x-on:click="showRoomProfile = false" icon="x-mark" icon:variant="outline" variant="subtle" />
         <flux:heading variant="strong">Room info</flux:heading>
-        <flux:button icon="pencil" class="ml-auto" icon:variant="outline" variant="subtle" />
     </header>
     <div class="flex h-full flex-col items-center space-y-2 p-4 dark:border-zinc-700">
-        <div class="mx-auto flex w-full flex-col items-center space-y-2 lg:max-w-md">
-            <div>
-                <img
-                    src="{{ $room->user->profile }}"
-                    class="h-28 w-28 rounded-full object-cover"
-                    alt="{{ $room->user->name }}"
+        {{-- Current room image upload --}}
+        <div class="mx-auto flex w-full flex-col items-center space-y-2 pt-2 lg:max-w-md">
+            <div class="group relative">
+                @if ($image && $image->isPreviewable())
+                    <img
+                        src="{{ $image->temporaryUrl() }}"
+                        class="h-28 w-28 rounded-full object-cover ring-4 ring-white dark:ring-zinc-800"
+                        alt="{{ $room->name }}"
+                    />
+                @else
+                    <img
+                        src="{{ $room->image }}"
+                        class="h-28 w-28 rounded-full object-cover ring-4 ring-white dark:ring-zinc-800"
+                        alt="{{ $room->image }}"
+                    />
+                @endif
+
+                <label
+                    for="room-image-upload"
+                    class="absolute inset-0 flex cursor-pointer items-center justify-center rounded-full bg-zinc-900/50 opacity-0 backdrop-blur-[1px] transition-opacity duration-200 group-hover:opacity-100 focus-within:opacity-100"
+                    aria-label="{{ __('Change Room Image') }}"
+                >
+                    <span class="flex flex-col items-center gap-1 text-white">
+                        <flux:icon.camera class="size-6" />
+                        <span class="text-xs font-medium">{{ __('Change') }}</span>
+                    </span>
+                </label>
+
+                <input
+                    id="room-image-upload"
+                    type="file"
+                    wire:model.live="image"
+                    accept="image/jpeg,image/png,image/jpg,image/webp,image/gif"
+                    class="hidden"
                 />
+
+                <div
+                    wire:loading
+                    wire:target="image"
+                    class="absolute inset-0 flex items-center justify-center rounded-full bg-white/80 dark:bg-zinc-900/80"
+                >
+                    <flux:icon.loading class="size-6 animate-spin text-zinc-600 dark:text-zinc-300" />
+                </div>
+            </div>
+
+            @if ($errors->has('image'))
+                <div
+                    x-data="{ show: true }"
+                    x-init="setTimeout(() => (show = false), 3000)"
+                    x-show="show"
+                    x-transition.opacity.duration.300ms
+                >
+                    <flux:error name="image" class="text-sm" />
+                </div>
+            @endif
+            {{-- <flux:error name="image" class="text-sm"/> --}}
+
+            <div wire:loading wire:target="image" class="text-xs text-zinc-500 dark:text-zinc-400">
+                {{ __('Uploading...') }}
             </div>
             <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>
             <p class="text-sm text-zinc-500 md:text-base dark:text-zinc-400">About</p>

--- a/resources/views/livewire/rooms/room-profile.blade.php
+++ b/resources/views/livewire/rooms/room-profile.blade.php
@@ -66,7 +66,87 @@
             </div>
             <h1 class="text-lg md:text-2xl">{{ $room->name }}</h1>
             <p class="text-sm text-zinc-500 md:text-base dark:text-zinc-400">About</p>
-            <p class="text-sm text-zinc-500 md:text-base dark:text-zinc-200">{{ $room->description ?: '--' }}</p>
+            <form
+                x-data="{
+                    isEditing: false,
+                    isDescriptionEmpty: ! @js($room->description),
+                    description: @js($room->description),
+
+                    editDescription() {
+                        this.isEditing = true;
+
+                        this.$nextTick(() => {
+                            this.$refs.textarea.focus();
+                            this.resizeTextarea();
+                        });
+                    },
+
+                     resizeTextarea() {
+                        const textarea = this.$refs.textarea;
+
+                        textarea.style.height = 'auto';
+                        textarea.style.height = textarea.scrollHeight + 'px';
+                    },
+
+                    resetForm(savedDescription) {
+                        this.isEditing = false;
+                        this.description = savedDescription;
+                        this.isDescriptionEmpty = ! savedDescription;
+                    }
+                }"
+                class="flex w-full items-center justify-between"
+                wire:submit="saveDescription"
+                x-on:description-saved.window="
+                    if ($event.detail.roomId === $wire.roomId) {
+                        resetForm($event.detail.description);
+                    }
+                "
+            >
+                <flux:button
+                    x-show="isDescriptionEmpty && ! isEditing"
+                    size="xs"
+                    variant="subtle"
+                    class="text-green-500!"
+                    @click="editDescription()"
+                >Add group description</flux:button>
+                <p x-show="! isEditing" class="text-sm md:text-base dark:text-zinc-200">{{ $room->description }}</p>
+                <textarea
+                    x-show="isEditing"
+                    x-ref="textarea"
+                    x-init="resizeTextarea()"
+                    @input="resizeTextarea()"
+                    wire:model="description"
+                    class="w-full resize-none border-0 px-2 py-1 focus:ring-0 focus:outline-none"
+                >{{ $room->description }}</textarea>
+                <div class="ml-auto self-start">
+                    <flux:button
+                        x-show="! isEditing"
+                        icon="pencil"
+                        variant="subtle"
+                        icon:variant="outline"
+                        @click="editDescription()"
+                    />
+                    <flux:button
+                        type="submit"
+                        x-show="isEditing"
+                        icon="check"
+                        variant="subtle"
+                        icon:variant="outline"
+                    />
+                </div>
+            </form>
+            {{-- description error --}}
+            @if ($errors->has('description'))
+                <div
+                    x-data="{ show: true }"
+                    x-init="setTimeout(() => (show = false), 3000)"
+                    x-show="show"
+                    x-transition.opacity.duration.300ms
+                    class="block w-full"
+                >
+                    <flux:error name="description" class="text-sm" />
+                </div>
+            @endif
         </div>
 
         <flux:separator class="my-5" />

--- a/resources/views/livewire/rooms/show.blade.php
+++ b/resources/views/livewire/rooms/show.blade.php
@@ -21,10 +21,10 @@
     x-on:room-selected.window="isActive = $event.detail.id === {{ $room->id }}"
 >
     <div class="flex items-center gap-3">
-        <figure class="relative flex-shrink-0">
+        <figure class="relative shrink-0">
             <img
-                src="{{ $room->user->profile }}"
-                alt="{{ $room->user->name }}"
+                src="{{ $room->image }}"
+                alt="{{ $room->name }}"
                 class="h-12 w-12 rounded-full object-cover ring-2 ring-zinc-200 dark:ring-zinc-600"
             />
             <div class="absolute -right-0.5 -bottom-0.5 h-4 w-4 rounded-full border-2 border-white bg-green-400 dark:border-zinc-800"></div>

--- a/tests/Unit/Livewire/Chats/IndexTest.php
+++ b/tests/Unit/Livewire/Chats/IndexTest.php
@@ -185,3 +185,35 @@ it('loads more chats without dispatching no-more-chats when more chats remain', 
         ->assertSet('offset', Index::LIMIT)
         ->assertNotDispatched('no-more-chats');
 });
+
+it('refreshes the computed room after a matching room-updated event', function (): void {
+    $user = User::factory()->create();
+    $room = Room::factory()
+        ->hasAttached($user, relationship: 'users')
+        ->create();
+
+    $room->update(['image' => 'room/'.$room->id.'/old-image.png']);
+
+    $component = Livewire::actingAs($user)
+        ->test(Index::class, ['roomId' => $room->id]);
+
+    $newImage = 'room/'.$room->id.'/new-image.png';
+    $room->update(['image' => $newImage]);
+
+    $component
+        ->dispatch('room-updated', roomId: $room->id)
+        ->assertSeeHtml('src="'.$newImage.'"');
+});
+
+it('ignores a room-updated event for another room', function (): void {
+    $user = User::factory()->create();
+    $room = Room::factory()
+        ->hasAttached($user, relationship: 'users')
+        ->create();
+    $otherRoom = Room::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class, ['roomId' => $room->id])
+        ->dispatch('room-updated', roomId: $otherRoom->id)
+        ->assertSet('roomId', $room->id);
+});

--- a/tests/Unit/Livewire/Rooms/RoomProfileTest.php
+++ b/tests/Unit/Livewire/Rooms/RoomProfileTest.php
@@ -86,3 +86,48 @@ test('room profile does nothing when no image is uploaded', function (): void {
 
     Storage::disk('public')->assertExists($room->image);
 });
+
+test('add group description for a room on room profile component', function (): void {
+    $room = Room::factory()->create([
+        'name' => 'Laravel Developers',
+        'description' => null,
+    ]);
+
+    $description = 'A place for Laravel developers to discuss PHP, Livewire, APIs, database design & other stuff';
+
+    expect($room->description)
+        ->toBeNull();
+
+    Livewire::actingAs($room->user)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
+        ->set('description', $description)
+        ->call('saveDescription')
+        ->assertSuccessful()
+        ->assertSee($description)
+        ->assertDispatched('description-saved');
+
+    $room->refresh();
+
+    expect($room->description)
+        ->not()->toBeNull();
+});
+
+test('remove room description from room profile component', function (): void {
+    $room = Room::factory()->create();
+
+    $description = $room->description;
+
+    expect($room->description)->not()->toBeNull();
+
+    Livewire::actingAs($room->user)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
+        ->set('description')
+        ->call('saveDescription')
+        ->assertSuccessful()
+        ->assertDontSee($description)
+        ->assertDispatched('description-saved');
+
+    $room->refresh();
+
+    expect($room->description)->toBeNull();
+});

--- a/tests/Unit/Livewire/Rooms/RoomProfileTest.php
+++ b/tests/Unit/Livewire/Rooms/RoomProfileTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Livewire\Rooms\RoomProfile;
 use App\Models\Room;
 use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
 use Livewire\Livewire;
 
 test('room profile renders room detail with members', function (): void {
@@ -18,7 +20,7 @@ test('room profile renders room detail with members', function (): void {
         ->assertSee('Room info')
         ->assertSee('Test Room')
         ->assertSee($room->users->count().' members')
-        ->assertSee($room->user->name)
+        ->assertSee($room->name)
         ->assertViewIs('livewire.rooms.room-profile');
 });
 
@@ -32,4 +34,55 @@ test('room profile denies access for unauthorized users', function (): void {
     Livewire::actingAs($otherUser)
         ->test(RoomProfile::class, ['roomId' => $room->id])
         ->assertStatus(403);
+});
+
+test('room profile uploads and replaces the room image', function (): void {
+    Storage::fake('public');
+
+    $room = Room::factory()->create();
+    $oldImage = 'room/'.$room->id.'/old-image.png';
+    Storage::disk('public')->put($oldImage, 'old image');
+    $room->update(['image' => $oldImage]);
+
+    $image = UploadedFile::fake()->image('new-image.png');
+
+    Livewire::actingAs($room->user)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
+        ->set('image', $image)
+        ->assertHasNoErrors()
+        ->assertSet('image', null)
+        ->assertDispatched('room-updated');
+
+    $room->refresh();
+
+    expect($room->image)
+        ->not->toBe($oldImage)
+        ->toStartWith('room/'.$room->id.'/');
+
+    Storage::disk('public')->assertMissing($oldImage);
+    Storage::disk('public')->assertExists($room->image);
+});
+
+test('room profile does nothing when no image is uploaded', function (): void {
+    Storage::fake('public');
+
+    $room = Room::factory()->create();
+
+    $existingImage = 'room/'.$room->id.'/existing.png';
+    $room->update([
+        'image' => $existingImage,
+    ]);
+
+    Storage::disk('public')->put($existingImage, 'existing image');
+
+    Livewire::actingAs($room->user)
+        ->test(RoomProfile::class, ['roomId' => $room->id])
+        ->set('image')
+        ->assertSet('image', null)
+        ->assertNotDispatched('room-updated');
+
+    expect($room->fresh()->getRawOriginal('image'))
+        ->toBe('room/'.$room->id.'/existing.png');
+
+    Storage::disk('public')->assertExists($room->image);
 });

--- a/tests/Unit/Livewire/Rooms/ShowTest.php
+++ b/tests/Unit/Livewire/Rooms/ShowTest.php
@@ -16,7 +16,45 @@ test('room card renders room details', function (): void {
 
     Livewire::test(Show::class, ['room' => $room])
         ->assertSee('Design review')
-        ->assertSee($room->user->name)
+        ->assertSee($room->name)
         ->assertSeeHtml('room-'.$room->id)
         ->assertSeeHtml('room-selected');
+});
+
+test('room card refreshes its room after a matching room-updated event', function (): void {
+    $room = Room::factory()
+        ->for(User::factory(), 'user')
+        ->create();
+
+    $oldImage = 'room/'.$room->id.'/old-image.png';
+    $room->update(['image' => $oldImage]);
+
+    $component = Livewire::test(Show::class, ['room' => $room->fresh()]);
+
+    $newImage = 'room/'.$room->id.'/new-image.png';
+    $room->update(['image' => $newImage]);
+
+    $component
+        ->dispatch('room-updated', roomId: $room->id)
+        ->assertSeeHtml('src="'.$newImage.'"');
+});
+
+test('room card ignores a room-updated event for another room', function (): void {
+    $room = Room::factory()
+        ->for(User::factory(), 'user')
+        ->create();
+
+    $oldImage = 'room/'.$room->id.'/old-image.png';
+    $room->update(['image' => $oldImage]);
+
+    $otherRoom = Room::factory()->create();
+    $component = Livewire::test(Show::class, ['room' => $room->fresh()]);
+
+    $newImage = 'room/'.$room->id.'/new-image.png';
+    $room->update(['image' => $newImage]);
+
+    $component->instance()->refreshRoom($otherRoom->id);
+
+    expect($component->instance()->room->getRawOriginal('image'))
+        ->toBe($oldImage);
 });

--- a/tests/Unit/Models/RoomTest.php
+++ b/tests/Unit/Models/RoomTest.php
@@ -16,6 +16,8 @@ test('to array', function (): void {
         'user_id',
         'created_at',
         'updated_at',
+        'image',
+        'user',
     ]);
 });
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/b3485059-dc76-4c64-bf06-3e87e608310e



### Summary
Allow users to add room images and descriptions directly from the room profile.
Image changes refresh the room card and chat header, and
successful description saves return the form to view mode.

### Changes:
- Add a nullable room image column, falling back to the owner’s avatar.
- Support image uploads and replacement with validation, previews,
  loading indicators, and success feedback.
- Refresh matching room cards on left rooms list section and chat headers after image updates.
- Allow adding, editing, and clearing descriptions with a 2,000-character limit.
- Auto-focus and resize the description editor, then close it after saving.

### Test coverage:
- Image replacement, old-file cleanup, and empty-upload handling.
- Room refresh events and ignoring updates for other rooms.
- Adding and removing descriptions.